### PR TITLE
Change project name to plantuml.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# PlantUML Web Assembly (WASM)
+# PlantUML.js
 
 PlantUML that works completely on the browser without needing a server.
 
-Demo URL: [https://plantuml.github.io/plantuml-wasm/](https://plantuml.github.io/plantuml-wasm/)
+Demo URL: [https://plantuml.github.io/plantuml.js/](https://plantuml.github.io/plantuml.js/)
 
-![plantuml web assembly](demo.png "PlantUML Web Assembly")
+![plantuml javascript](demo.png "PlantUML javascript")
 
 # Features of the editor
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PlantUML WASM</title>
+    <title>PlantUML.js Playground</title>
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <script src="https://cjrtnc.leaningtech.com/2.3/loader.js"></script>
     <script src="plantuml-wasm/plantuml.js"></script>
@@ -38,7 +38,7 @@
             <div id="sidebar" class="bg-gray-900 h-screen md:block shadow-xl px-0 w-full overflow-x-hidden transition-transform duration-300 ease-in-out">
               <div class="space-y-2 md:space-y-2 mt-2">
                 <h1 class="md:block font-bold text-sm md:text-xl text-center px-3 text-white" id="logo-title">
-                  <span>PlantUML WASM</span>
+                  <span>PlantUML.js Playground</span>
                 </h1>
                 <div class="px-3">
                   <select id="example-files" placeholder="Choose an example..." class="example-files"></select>

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@ Bob -> Alice: Hello!
           <div id="resizer" class="vertical bg-gray-50"></div>
           <main class="p-4 w-full h-full">
             <div class="space-x-2 flex justify-end text-right">
-              <a href="https://github.com/plantuml/plantuml-wasm/new/main/playground/example-pumls/community/?filename=community/new_diagram.puml&value=%40startuml%0A%27%20Copy%20your%20diagram%20content%20here%0A%40enduml%0A" target="_blank">Share this diagram with the Community</a>
-              <a href="https://github.com/plantuml/plantuml-wasm" target="_blank">Github</a>
+              <a href="https://github.com/plantuml/plantuml.js/new/main/playground/example-pumls/community/?filename=community/new_diagram.puml&value=%40startuml%0A%27%20Copy%20your%20diagram%20content%20here%0A%40enduml%0A" target="_blank">Share this diagram with the Community</a>
+              <a href="https://github.com/plantuml/plantuml.js" target="_blank">Github</a>
             </div>
             <div id="right-panel-image-wrapper" class="flex justify-center">
               <img id="render-image" src="playground/assets/loading.png" />

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       #logo-title{
         background-image: url("playground/assets/logo.png") !important;
         background-repeat: no-repeat !important;
-        background-position: left 30% top 50% !important;
+        background-position: left 24% top 50% !important;
         background-size: 30px 30px !important;
       }
     </style>


### PR DESCRIPTION
# Why

We're not exactly using web assembly, and also WASM is harder for people to understand. That's why I'm renaming it to plantuml.js, similar pattern here: https://github.com/asciidoctor/asciidoctor.js/

# What

- Change project name and all the links

# Checklist

- [x] Rendering on Preview tested:
    - Basic rendering
    - Stdlib rendering
    - Rendering with refreshing the page after choosing an example
- [x] Documentation is updated
